### PR TITLE
Add correct comment style.

### DIFF
--- a/scoped-properties/language-purescript.cson
+++ b/scoped-properties/language-purescript.cson
@@ -1,0 +1,3 @@
+'.source.purescript':
+  'editor':
+    'commentStart': '-- '


### PR DESCRIPTION
This pull request fixes the comment format used when using the `⌘ + /`keyboard shortcut.

Currently `/**/` is used. Accepting this pull request would mean that `-- ` is used instead.